### PR TITLE
feat: Enhance Tizen VTS test harness capabilities

### DIFF
--- a/tizen-vts/docs/TEST_EXECUTION.md
+++ b/tizen-vts/docs/TEST_EXECUTION.md
@@ -32,6 +32,8 @@ The harness supports several command-line options:
 *   `--test-dir <path>`: Specifies the directory on the host where compiled test executables are located. Defaults to `tizen-vts/build/bin/` (relative to the `tizen-vts` root).
 *   `--sdb-path <path>`: Path to the `sdb` executable if it's not in your system's PATH.
 *   `--target-id <device_serial>` or `-s <device_serial>`: Specifies the target Tizen device by its serial number if multiple devices are connected.
+*   `--gtest_filter <GTEST_FILTER_PATTERN>`: An optional argument for the `run_test` command that allows you to pass a filter pattern directly to the GTest executable. This is useful for running a subset of tests within a larger test executable. The pattern follows GTest's filter syntax (e.g., `TestSuiteName.*` to run all tests in `TestSuiteName`, `*Positive*` to run tests containing "Positive", or `-TestSuiteName.TestToExclude` to exclude a specific test). Example: `python3 harness/tizen_vts_cli.py run_test sample_hal_test --gtest_filter="*Power*"`
+*   `-v`, `--verbose`: Increase output verbosity. Use multiple times for more detail (e.g., `-v` for basic verbose messages including SDB commands, `-vv` for more detailed SDB command outputs like stderr). Useful for debugging or understanding harness operations.
 
 **Note on Paths:**
 *   **Host Results Directory:** XML results and HTML reports are saved in `tizen-vts/results/` on the host machine. This is currently a fixed path.
@@ -47,18 +49,29 @@ python3 harness/tizen_vts_cli.py list_tests
 # python3 harness/tizen_vts_cli.py --test-dir my_custom_build/bin list_tests
 ```
 
-### Running a Single Test
+### Running Tests (Single or Multiple)
 
-To run a specific test executable (e.g., `sample_hal_test`):
+To run a specific test executable (e.g., `sample_hal_test`) or a group of tests matching a pattern:
 
 ```bash
 python3 harness/tizen_vts_cli.py run_test sample_hal_test
+python3 harness/tizen_vts_cli.py run_test sample_*_test
+python3 harness/tizen_vts_cli.py run_test *_kernel_*
 ```
+
+If the pattern matches multiple test executables, the harness will run each one sequentially.
+
+The `--gtest_filter` option can be used in conjunction with patterns. The GTest filter will be applied to *each* test executable that matches the `test_pattern`. For example:
+
+```bash
+python3 harness/tizen_vts_cli.py run_test sample_*_test --gtest_filter="*Power*"
+```
+This would run all tests containing "Power" within `sample_hal_test` (if it matches the `sample_*_test` pattern) and then all tests containing "Power" within `sample_kernel_test` (if it also matches), etc.
 
 If you have multiple devices connected, specify the target:
 
 ```bash
-python3 harness/tizen_vts_cli.py -s <your_device_serial> run_test sample_hal_test
+python3 harness/tizen_vts_cli.py -s <your_device_serial> run_test sample_*_test --gtest_filter="*Power*"
 ```
 
 The harness will:
@@ -75,20 +88,9 @@ The harness will:
 
 ### Running Multiple Tests (Current Approach)
 
-Currently, the `run_test` command executes one test *executable* at a time. A single test executable can contain multiple test cases and test suites (as defined by GTest).
+The `run_test` command now supports patterns for the test executable name. It can execute a single test if the pattern is an exact name, or multiple tests if the pattern uses wildcards (e.g., `*`, `?`). Each matched test executable will be run sequentially.
 
-To run all tests or a subset of tests defined in different executables, you would typically use a shell script or another automation layer to call `python3 harness/tizen_vts_cli.py run_test ...` multiple times.
-
-Example (in a bash script):
-```bash
-#!/bin/bash
-# tests_to_run.sh
-python3 harness/tizen_vts_cli.py run_test sample_hal_test
-python3 harness/tizen_vts_cli.py run_test sample_kernel_test
-# Add more tests as needed
-```
-
-Future enhancements to the harness may include support for test plans to manage execution of multiple test executables.
+A single test executable can contain multiple test cases and test suites (as defined by GTest). The `--gtest_filter` can be used to run a subset of these test cases within each matched executable.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This commit introduces several enhancements to the CLI test harness (`harness/tizen_vts_cli.py`):

1.  **GTest Filter Pass-through:**
    - Added a `--gtest_filter <GTEST_FILTER_PATTERN>` option to the `run_test` command. This allows you to specify GTest filter strings (e.g., "TestSuite.*", "*Positive*") to control which specific tests are run within a test executable.

2.  **Test Executable Pattern Matching:**
    - The `run_test` command's `test_name` argument has been changed to `test_pattern`. It now accepts shell-like wildcard patterns (e.g., "sample_*_test", "*_hal_test") to run multiple matching test executables sequentially.

3.  **Verbose Logging:**
    - Introduced a `-v, --verbose` option (cumulative, e.g., -v, -vv) to increase the verbosity of console output.
    - Verbose logs include timestamps, detailed SDB commands, internal harness actions, and more comprehensive error details, aiding in debugging and understanding harness operations.

4.  **Code Refactoring:**
    - The `run_test_action` function was internally refactored by creating an `_execute_single_test_workflow` helper function. This improves code modularity and maintainability without changing external behavior.

The documentation file `docs/TEST_EXECUTION.md` has been updated to reflect these new command-line options and functionalities. These changes make the test harness more flexible, user-friendly, and easier to debug.